### PR TITLE
Fix #2 : page refresh in subdirs 

### DIFF
--- a/nextjs/next.config.js
+++ b/nextjs/next.config.js
@@ -12,4 +12,5 @@ module.exports = {
   future: {
     webpack5: true,
   },
+  trailingSlash: true,
 };


### PR DESCRIPTION
In the current version, when you refresh the page in the /foo or /foo/bar pages, it doesn't work as expected. 

This fix change the generation of html files to remove that issue.

This is the new generated file structure for the ui :
```
nextjs/dist/
├── 404
│   └── index.html
├── foo
│   ├── bar
│   │   └── index.html
│   └── index.html
├── index.html
```